### PR TITLE
Fix for mkdir failing to create nested directories (on a new setup)

### DIFF
--- a/src/Devitek/Core/Config/LoadYamlConfiguration.php
+++ b/src/Devitek/Core/Config/LoadYamlConfiguration.php
@@ -122,7 +122,7 @@ class LoadYamlConfiguration extends LoadConfiguration
      */
     protected function parseYamlOrLoadFromCache($file)
     {
-        $cachedir  = sprintf('%s/devitek/cache/yaml-configuration/', storage_path());
+        $cachedir  = sprintf('%s/yaml-configuration/', storage_path());
         $cachefile = $cachedir . 'cache.' . md5($file) . '.php';
 
         if (@filemtime($cachefile) < filemtime($file)) {


### PR DESCRIPTION
mkdir wont create nested directories by default. So keep the cache folder structure simple to prevent this problem and make sure mkdir will create the cache directory on a new setup if its not there. Alternatively if you want to keep the nested folder structure for some reason you need to do @mkdir($cachedir, 0755, true); dont see a reason why this needs to be 3 folders deep so kept it simple. :)