### PR TITLE
fix composer, illuminate -> laravel/framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ And select version : ```2.*```
 
 You have to add (or merge)
 
-```
+```php
 protected function bootstrappers()
 {
-    return array_merge($this->bootstrappers, [\\Devitek\\Core\\Config\\LoadYamlConfiguration::class]);
+    $this->bootstrappers[] = 'Devitek\Core\Config\LoadYamlConfiguration';
+    return $this->bootstrappers;
 }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/config": "5.*",
-        "illuminate/foundation": "5.*",
+        "laravel/framework": "5.*",
         "symfony/yaml": "2.*"
     },
     "autoload": {


### PR DESCRIPTION
install will fail in the composer.
logs:
```
  Problem 1
    - Installation request for devitek/yaml-configuration ^2.2 -> satisfiable by devitek/yaml-configuration[2.2].
    - devitek/yaml-configuration 2.2 requires illuminate/foundation 5.* -> no matching package found.
```

illuminate/foundation of version 5.* had no longer exists.
https://packagist.org/packages/illuminate/foundation

so, remove the illuminate package from require, we specified the laravel/framework in place.

and, in the designation of bootstrappers of README it has been modified so did not run.
